### PR TITLE
Suport for CSS transitions when rotating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 Leaflet Rotated Marker
 ===
 
-Enables rotation of marker icons in Leaflet. [Demo](http://bbecquet.github.io/Leaflet.RotatedMarker/example.html)
+Enables rotation of marker icons in Leaflet. [Demo](http://bbecquet.github.io/Leaflet.RotatedMarker/example.html).
+
+Marker icons are rotated clockwise/counterclockwise in order to reach the desired angle using as little rotation as possible.
+This is especially important when CSS transitions is used on the icon in order to achieve a smooth transition/animation when moving/rotating the marker e.g.
+```js
+$(myMarker).css("transition", "transform 0.25s linear");
+```
 
 Compatible with versions 0.7.* and 1.* of Leaflet. Doesn't work on IE < 9.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@ Leaflet Rotated Marker
 Enables rotation of marker icons in Leaflet. [Demo](http://bbecquet.github.io/Leaflet.RotatedMarker/example.html).
 
 Marker icons are rotated clockwise/counterclockwise in order to reach the desired angle using as little rotation as possible.
-This is especially important when CSS transitions is used on the icon in order to achieve a smooth transition/animation when moving/rotating the marker e.g.
-```js
-$(myMarker).css("transition", "transform 0.25s linear");
-```
+(This is important when CSS transitions is used on the icon in order to achieve a smooth transition/animation when moving/rotating the marker e.g.)
+
 
 Compatible with versions 0.7.* and 1.* of Leaflet. Doesn't work on IE < 9.
 

--- a/leaflet.rotatedMarker.js
+++ b/leaflet.rotatedMarker.js
@@ -4,6 +4,7 @@
     var proto_setPos = L.Marker.prototype._setPos;
 
     var oldIE = (L.DomUtil.TRANSFORM === 'msTransform');
+    var rot = 0;
 
     L.Marker.addInitHook(function () {
         var iconOptions = this.options.icon && this.options.icon.options;
@@ -34,12 +35,23 @@
             if(this.options.rotationAngle) {
                 this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
 
+                // Calculate closest rotation angle (clockwise or counterclockwise)
+                // https://stackoverflow.com/questions/19618745/css3-rotate-transition-doesnt-take-shortest-way
+                var nR = this.options.rotationAngle;
+                var aR;
+                this.rot = this.rot || 0; // if rot undefined or 0, make 0, else rot
+                aR = this.rot % 360;
+                if ( aR < 0 ) { aR += 360; }
+                if ( aR < 180 && (nR > (aR + 180)) ) { this.rot -= 360; }
+                if ( aR >= 180 && (nR <= (aR - 180)) ) { this.rot += 360; }
+                this.rot += (nR - aR);
+        
                 if(oldIE || !this.options.accelerated) {
                     // for IE 9, use the 2D rotation
-                    this._icon.style[L.DomUtil.TRANSFORM] = 'rotate(' + this.options.rotationAngle + 'deg)';
+                    this._icon.style[L.DomUtil.TRANSFORM] = 'rotate(' + this.rot + 'deg)';
                 } else {
                     // for modern browsers, prefer the 3D accelerated version
-                    this._icon.style[L.DomUtil.TRANSFORM] += ' rotateZ(' + this.options.rotationAngle + 'deg)';
+                    this._icon.style[L.DomUtil.TRANSFORM] += ' rotateZ(' + this.rot + 'deg)';
                 }
             }
         },


### PR DESCRIPTION
Marker icons are rotated clockwise/counterclockwise in order to reach the desired angle using as little rotation as possible.
(This is important when CSS transitions is used on the icon in order to achieve a smooth transition/animation when moving/rotating the marker e.g.)

Without fix:

https://github.com/tmgreensolutions/Leaflet.RotatedMarker/assets/1677884/647cfdec-3a0f-4cd0-9da7-5430af294d45

